### PR TITLE
fix: Update about page

### DIFF
--- a/www/about.html
+++ b/www/about.html
@@ -113,10 +113,10 @@
             </tr>
             <tr>
               <th scope="row">
-                <a href="https://tools.ietf.org/tools/idnits/">idnits</a>
+                <a href="https://github.com/ietf-tools/idnits">idnits</a>
               </th>
               <td><span id="spanIdnits"></span></td>
-              <td><a href="https://tools.ietf.org/tools/idnits/copyright">GNU General Public License</a></td>
+              <td><a href="https://github.com/ietf-tools/idnits/raw/main/copyright">GNU General Public License</a></td>
             </tr>
             <tr>
               <th scope="row">

--- a/www/about.html
+++ b/www/about.html
@@ -85,10 +85,10 @@
             </tr>
             <tr>
               <th scope="row">
-                <a href="https://pypi.org/project/xml2rfc/">xml2rfc</a>
+                <a href="https://github.com/ietf-tools/xml2rfc">xml2rfc</a>
               </th>
               <td><span id="spanXml2rfc"></span></td>
-              <td><a href="https://trac.ietf.org/trac/xml2rfc/browser/trunk/cli/LICENSE">BSD 3-Clause License</a></td>
+              <td><a href="https://github.com/ietf-tools/xml2rfc/raw/main/LICENSE">BSD 3-Clause License</a></td>
             </tr>
             <tr>
               <th scope="row">

--- a/www/about.html
+++ b/www/about.html
@@ -81,7 +81,7 @@
                 <a href="https://github.com/ietf-tools/ietf-at">Author Tools - API</a>
               </th>
               <td><span id="spanIetfat"></span></td>
-              <td><a href="https://github.com/ietf-tools/ietf-at/blob/main/LICENSE">Revised BSD License</a></td>
+              <td><a href="https://github.com/ietf-tools/ietf-at/raw/main/LICENSE">Revised BSD License</a></td>
             </tr>
             <tr>
               <th scope="row">
@@ -95,14 +95,14 @@
                 <a href="https://github.com/cabo/kramdown-rfc">kramdown-rfc</a>
               </th>
               <td><span id="spanKramdown"></span></td>
-              <td><a href="https://github.com/cabo/kramdown-rfc/blob/master/LICENSE">MIT License</a></td>
+              <td><a href="https://github.com/cabo/kramdown-rfc/raw/master/LICENSE">MIT License</a></td>
             </tr>
             <tr>
               <th scope="row">
                 <a href="https://mmark.miek.nl/">mmark</a>
               </th>
               <td><span id="spanMmark"></span></td>
-              <td><a href="https://github.com/mmarkdown/mmark/blob/master/LICENSE">Simplified BSD License</a></td>
+              <td><a href="https://github.com/mmarkdown/mmark/raw/master/LICENSE">Simplified BSD License</a></td>
             </tr>
             <tr>
               <th scope="row">
@@ -123,21 +123,21 @@
                 <a href="https://github.com/ietf-tools/iddiff">iddiff</a>
               </th>
               <td><span id="spanIddiff"></span></td>
-              <td><a href="https://github.com/ietf-tools/iddiff/blob/main/LICENSE">Revised BSD License</a></td>
+              <td><a href="https://github.com/ietf-tools/iddiff/raw/main/LICENSE">Revised BSD License</a></td>
             </tr>
             <tr>
               <th scope="row">
                 <a href="https://weasyprint.org/">WeasyPrint</a>
               </th>
               <td><span id="spanWeasyprint"></span></td>
-              <td><a href="https://github.com/Kozea/WeasyPrint/blob/master/LICENSE">BSD 3-Clause License</a></td>
+              <td><a href="https://github.com/Kozea/WeasyPrint/raw/master/LICENSE">BSD 3-Clause License</a></td>
             </tr>
             <tr>
               <th scope="row">
                 <a href="https://github.com/martinthomson/aasvg/">aasvg</a>
               </th>
               <td><span id="spanAasvg"></span></td>
-              <td><a href="https://github.com/martinthomson/aasvg/blob/main/LICENSE">Simplified BSD License</a></td>
+              <td><a href="https://github.com/martinthomson/aasvg/raw/main/LICENSE">Simplified BSD License</a></td>
             </tr>
           </table>
         </div>


### PR DESCRIPTION
Fixes #97 

* fix: Update xml2rfc links in about page
* fix: Change GitHub license URLs in about page to raw views
* fix: Change URLs for idnits in about page