### PR TITLE
feat: Add sentry integration

### DIFF
--- a/www/abnf.html
+++ b/www/abnf.html
@@ -166,5 +166,10 @@
       })();
     </script>
     <!-- End Matomo Code -->
+    <!-- Sentry -->
+    <script
+      src="https://js.sentry-cdn.com/7df43064661046f4b69e406c91ddda41.min.js"
+      crossorigin="anonymous"></script>
+    <!-- End Sentry Code -->
   </body>
 </html>

--- a/www/about.html
+++ b/www/about.html
@@ -225,5 +225,9 @@
       })();
     </script>
     <!-- End Matomo Code -->
+    <script
+      src="https://js.sentry-cdn.com/7df43064661046f4b69e406c91ddda41.min.js"
+      crossorigin="anonymous"></script>
+    <!-- End Sentry Code -->
   </body>
 </html>

--- a/www/doc/index.html
+++ b/www/doc/index.html
@@ -161,5 +161,10 @@
     })();
   </script>
   <!-- End Matomo Code -->
+  <!-- Sentry -->
+    <script
+      src="https://js.sentry-cdn.com/7df43064661046f4b69e406c91ddda41.min.js"
+      crossorigin="anonymous"></script>
+  <!-- End Sentry Code -->
   </body>
 </html>

--- a/www/iddiff.html
+++ b/www/iddiff.html
@@ -176,5 +176,10 @@
       })();
     </script>
     <!-- End Matomo Code -->
+    <!-- Sentry -->
+    <script
+      src="https://js.sentry-cdn.com/7df43064661046f4b69e406c91ddda41.min.js"
+      crossorigin="anonymous"></script>
+    <!-- End Sentry Code -->
   </body>
 </html>

--- a/www/index.html
+++ b/www/index.html
@@ -202,5 +202,10 @@
       })();
     </script>
     <!-- End Matomo Code -->
+    <!-- Sentry -->
+    <script
+      src="https://js.sentry-cdn.com/7df43064661046f4b69e406c91ddda41.min.js"
+      crossorigin="anonymous"></script>
+    <!-- End Sentry Code -->
   </body>
 </html>


### PR DESCRIPTION
This PR adds sentry integration to capture JavaScript errors on the web browser.
Some privacy plugins block **Sentry** because it's a telemetry service.
We need to review the privacy implications before merging this PR.