### PR TITLE
fix: Update valdation results

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -145,8 +145,8 @@
             </div>
             <div class="accordion-item" id="accordionItemBareUnicode">
               <h2 class="accordion-header" id="panelsBareUnicodeHeading">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsBareUnicode" aria-expanded="true" aria-controls="panelsBareUnicode">
-                  Bare Unicode Usage
+                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsBareUnicode" aria-expanded="true" aria-controls="panelsBareUnicode" title="These are not warnings. For informational purposes only.">
+                  INFORMATIONAL: Bare Unicode Usage
                 </button>
               </h2>
               <div id="panelsBareUnicode" class="accordion-collapse collapse show" aria-labelledby="panelsBareUnicodeHeading">
@@ -157,8 +157,8 @@
             </div>
             <div class="accordion-item" id="accordionItemNonASCII">
               <h2 class="accordion-header" id="panelsNonASCIIHeading">
-                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsNonASCII" aria-expanded="true" aria-controls="panelsNonASCII">
-                  Non-ASCII Characters (kramdown-rfc echars)
+                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#panelsNonASCII" aria-expanded="true" aria-controls="panelsNonASCII" title="These are not warnings. For informational purposes.">
+                  INFORMATIONAL: Non-ASCII Characters (kramdown-rfc echars)
                 </button>
               </h2>
               <div id="panelsNonASCII" class="accordion-collapse collapse show" aria-labelledby="panelsNonASCIIHeading">


### PR DESCRIPTION
Update validation results to let the user know that non-ASCII reports are for informational purposes and not warnings.

Fixes #169